### PR TITLE
[JENKINS-21970] enable checkbox on rebuild

### DIFF
--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
@@ -86,7 +86,7 @@ private void drawMainBall(Combination combination,AxisList axes,String matrixNam
     if (lastBuild != null && lastBuild.getRun(combination)!=null){
         lastRun = lastBuild.getRun(combination);
         if (lastRun != null){
-            a(href:request.getRootPath()+"/"+lastRun.getUrl()){
+            a(href:rootURL+"/"+lastRun.getUrl()){
             img(src: "${imagesURL}/24x24/"+lastRun.getBuildStatusUrl())
             if (!layouter.x || !layouter.y) {
               text(combination.toString(layouter.z))

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/rebuild.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/rebuild.groovy
@@ -47,7 +47,7 @@ private void drawTableBall(MatrixBuild.RunPtr runPtr,AxisList axes,matrixValue,M
     run = runPtr.getRun();
     result = matrixValue.combinationExists(runPtr.combination);
     if (result){
-        a(href:request.getRootPath()+"/"+run.getUrl()){
+        a(href:rootURL+"/"+run.getUrl()){
             img(src: "${imagesURL}/24x24/"+run.getBuildStatusUrl());
             if (!layouter.x || !layouter.y) {
               text(runPtr.combination.toString(layouter.z))

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/value.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/value.groovy
@@ -99,7 +99,7 @@ private void drawTableBall(MatrixBuild.RunPtr runPtr,AxisList axes,MatrixCombina
     run = runPtr.getRun();
     result = matrixValue.combinationExists(runPtr.combination);
     if (result){
-        a(href:request.getRootPath()+"/"+run.getUrl()){
+        a(href:rootURL+"/"+run.getUrl()){
             img(src: "${imagesURL}/24x24/"+run.getBuildStatusUrl());
             f.checkbox(checked: "true",onclick:"return false;", onkeydown:"return false;", name: "values",id: "checkbox"+matrixValue.getName());
             input(type: "hidden", name: "confs", value: runPtr.combination.toString());


### PR DESCRIPTION
Fix for [JENKINS-21970](https://issues.jenkins-ci.org/browse/JENKINS-21970).
When displaying a rebuild page with a matrix-combinations parameter, I cannot toggle combination checkboxes as they are in anchor tags and the browser opens a new page.
This pull request moves checkboxes out of anchor tags.

If this is an intended design to have users not to change combinations, please decline this request.
