### PR TITLE
[JENKINS-27233] Fixed exceptions in rebuild pages with non-matrix projects

### DIFF
--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
@@ -13,13 +13,21 @@ f = namespace("lib/form")
 nsProject = namespace("/hudson/plugins/matrix_configuration_parameter/taglib")
 
 
-MatrixProject project = request.findAncestorObject(MatrixProject.class);
-if (project == null)   //in case project is not a Matrix Project
-    return;
-
-AxisList axes =  project.getAxes();
 def paramDef = it;
 String nameIt = it.getName();
+MatrixProject project = request.findAncestorObject(MatrixProject.class);
+if (project == null) {
+   //in case project is not a Matrix Project
+    f.entry(title: nameIt, description: it.getDescription()) {
+        div(name: "parameter") {
+            input(type: "hidden", name: "name", value: nameIt)
+            text(_("Not applicable. Applicable only to multi-configuration projects."))
+        }//div
+    }
+    return;
+}
+
+AxisList axes =  project.getAxes();
 Layouter layouter = new Layouter<Combination>(axes) {
     protected Combination getT(Combination c) {
         return c;

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/rebuild.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/rebuild.groovy
@@ -16,12 +16,21 @@ f = namespace("lib/form")
 nsProject = namespace("/hudson/plugins/matrix_configuration_parameter/taglib")
 
 
-MatrixProject project = request.findAncestorObject(MatrixProject.class);
-AxisList axes = project.getAxes();
-MatrixBuild build = request.findAncestorObject(MatrixBuild.class);
-if (build == null) //in case you are looking at a specific run, MatrixRun Ancestor will replace the MatrixBuild
-    return;
 def valueIt = it;
+
+MatrixProject project = request.findAncestorObject(MatrixProject.class);
+MatrixBuild build = request.findAncestorObject(MatrixBuild.class);
+if (project == null || build == null) {
+    //in case you are looking at a specific run, MatrixRun Ancestor will replace the MatrixBuild
+    f.entry(title: valueIt.getName(), description: it.getDescription()) {
+        // In the case the parameter is not defined in this project,
+        // sending parameters cause rebuild-plugin throws exception.
+        // Acts as if I'm not here.
+        text(_("Not applicable. Applicable only to multi-configuration projects."))
+    }
+    return;
+}
+AxisList axes = project.getAxes();
 Layouter layouter = new Layouter<Combination>(axes) {
     protected Combination getT(Combination c) {
         return c;

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/value.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/value.groovy
@@ -15,12 +15,20 @@ st = namespace("jelly:stapler")
 f = namespace("lib/form")
 nsProject = namespace("/hudson/plugins/matrix_configuration_parameter/taglib")
 
-MatrixProject project = request.findAncestorObject(MatrixProject.class);
-AxisList axes = project.getAxes();
-MatrixBuild build = request.findAncestorObject(MatrixBuild.class);
-if (build == null) //in case you are looking at a specific run, MatrixRun Ancestor will replace the MatrixBuild
-    return;
 MatrixCombinationsParameterValue valueIt = it;
+MatrixProject project = request.findAncestorObject(MatrixProject.class);
+MatrixBuild build = request.findAncestorObject(MatrixBuild.class);
+if (project == null || build == null) {
+    //in case you are looking at a specific run, MatrixRun Ancestor will replace the MatrixBuild
+    f.entry(title: valueIt.getName(), description: it.getDescription()) {
+        div(name: "parameter") {
+            input(type: "hidden", name: "name", value: valueIt.getName())
+            text(_("Not applicable. Applicable only to multi-configuration projects."))
+        }//div
+    }
+    return;
+}
+AxisList axes = project.getAxes();
 Layouter layouter = new Layouter<Combination>(axes) {
     protected Combination getT(Combination c) {
         return c;

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinitionTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinitionTest.java
@@ -30,6 +30,8 @@ import hudson.matrix.Combination;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.model.Result;
@@ -441,5 +443,27 @@ public class MatrixCombinationsParameterDefinitionTest {
         wc.getPage(p, "build");
         
         f.cancel(true);
+    }
+    
+    @Test
+    public void testAppliedForNonMatrixProject() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(
+                new MatrixCombinationsParameterDefinition("combinations", "", "")
+        ));
+        
+        {
+            WebClient wc = j.createAllow405WebClient();
+            HtmlPage page = wc.getPage(p, "build");
+            j.submit(page.getFormByName("parameters"));
+            
+            j.waitUntilNoActivity();
+            FreeStyleBuild b = p.getLastBuild();
+            assertNotNull(b);
+            j.assertBuildStatusSuccess(b);
+        }
+        
+        // default trigger
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 }

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValueTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValueTest.java
@@ -25,14 +25,22 @@
 package hudson.plugins.matrix_configuration_parameter;
 
 import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
@@ -91,5 +99,24 @@ public class MatrixCombinationsParameterValueTest {
         assertFalse(((HtmlCheckBoxInput)page.getElementById("checkboxcombinations-axis1-value1-1-axis2-value2-2")).isChecked());
         assertTrue(((HtmlCheckBoxInput)page.getElementById("checkboxcombinations-axis1-value1-2-axis2-value2-1")).isChecked());
         assertTrue(((HtmlCheckBoxInput)page.getElementById("checkboxcombinations-axis1-value1-2-axis2-value2-2")).isChecked());
+    }
+    
+    @Bug(27233)
+    @Test
+    public void testNonMatrixBuild() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        
+        @SuppressWarnings("deprecation")
+        Cause cause = new Cause.UserCause();
+        FreeStyleBuild b = p.scheduleBuild2(0, cause, Arrays.asList(
+                new ParametersAction(new MatrixCombinationsParameterValue(
+                        "combinations",
+                        new Boolean[]{ true, false, true },
+                        new String[]{ "axis1=value1", "axis1=value2", "axis1=value3" }
+                ))
+        )).get();
+        
+        WebClient wc = j.createWebClient();
+        wc.getPage(b, "parameters");
     }
 }


### PR DESCRIPTION
[JENKINS-27233](https://issues.jenkins-ci.org/browse/JENKINS-27233)

Now it displays "Not applicable"
* Build page
![build](https://cloud.githubusercontent.com/assets/3115961/8390243/92e40678-1cc5-11e5-9c5c-f45d992d7599.png)
* Parameter page
![parameter](https://cloud.githubusercontent.com/assets/3115961/8390244/9b2e7e12-1cc5-11e5-9dfb-a9be6966adf1.png)
* Rebuild page
![rebuild](https://cloud.githubusercontent.com/assets/3115961/8390246/a5024068-1cc5-11e5-8032-c9c762bc7a56.png)
