### PR TITLE
Improve the way to pass values

### DIFF
--- a/src/main/java/hudson/plugins/matrix_configuration_parameter/DefaultMatrixCombinationsParameterValue.java
+++ b/src/main/java/hudson/plugins/matrix_configuration_parameter/DefaultMatrixCombinationsParameterValue.java
@@ -33,8 +33,8 @@ import hudson.util.VariableResolver;
  * {@link MatrixCombinationsParameterValue} created when the build started
  * without specifying parameter.
  * 
- * {@link MatrixCombinationsParameterValue#getConfs()} and {@link MatrixCombinationsParameterValue#getValues()}
- * does not work (always return an empty array).
+ * {@link MatrixCombinationsParameterValue#getCombinations()}
+ * does not work (always return an empty list).
  */
 public class DefaultMatrixCombinationsParameterValue extends MatrixCombinationsParameterValue {
     private static final long serialVersionUID = -812826069693143705L;
@@ -45,6 +45,15 @@ public class DefaultMatrixCombinationsParameterValue extends MatrixCombinationsP
         this.combinationFilter = combinationFilter;
     }
     
+
+    /**
+     * @return combination filter
+     * @since 1.1.0
+     */
+    public String getCombinationFilter() {
+        return combinationFilter;
+    }
+
     @Override
     public VariableResolver<String> createVariableResolver(AbstractBuild<?, ?> build) {
         return new VariableResolver<String>() {
@@ -72,7 +81,7 @@ public class DefaultMatrixCombinationsParameterValue extends MatrixCombinationsP
         }
         return c.evalGroovyExpression(axes, combinationFilter);
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/src/main/java/hudson/plugins/matrix_configuration_parameter/DefaultMatrixCombinationsParameterValue.java
+++ b/src/main/java/hudson/plugins/matrix_configuration_parameter/DefaultMatrixCombinationsParameterValue.java
@@ -41,7 +41,7 @@ public class DefaultMatrixCombinationsParameterValue extends MatrixCombinationsP
     private final String combinationFilter;
     
     public DefaultMatrixCombinationsParameterValue(String name, String description, String combinationFilter) {
-        super(name, new Boolean[0], new String[0], description);
+        super(name, description, null);
         this.combinationFilter = combinationFilter;
     }
     

--- a/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue.java
+++ b/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue.java
@@ -24,7 +24,10 @@
 package hudson.plugins.matrix_configuration_parameter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
@@ -35,29 +38,85 @@ import hudson.util.VariableResolver;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
 
 public class MatrixCombinationsParameterValue extends ParameterValue {
 
-    Boolean[] values;
-    String[] confs;
+    private final List<String> combinations;
 
+    @Deprecated
+    transient Boolean[] values;
+    @Deprecated
+    transient String[] confs;
+
+    /**
+     * ctor
+     *
+     * @param name name of parameter
+     * @param combinations combinations to build
+     * @since 1.1.0
+     */
     @DataBoundConstructor
+    public MatrixCombinationsParameterValue(String name, String description, List<String> combinations) {
+        super(name,  description);
+        this.combinations = (combinations != null)
+            ? Collections.unmodifiableList(combinations)
+            : Collections.<String>emptyList();
+    }
+
+    @Deprecated
     public MatrixCombinationsParameterValue(String name, Boolean[] values, String[] confs) {
         this(name, values, confs, null);
     }
 
+    @Deprecated
     public MatrixCombinationsParameterValue(String name, Boolean[] values, String[] confs, String description) {
-        super(name,  description);
-        this.values = (values != null) ? values.clone() : null;
-        this.confs = (confs != null) ? confs.clone() : null;
+        this(name, description, convertValuesAndConfs(values, confs));
     }
 
+    @Deprecated
     public Boolean[] getValues() {
         return (values != null) ? values.clone() : null;
     }
 
+    @Deprecated
     public String[] getConfs() {
         return (confs != null) ? confs.clone() : null;
+    }
+
+    /**
+     * @return combinations to build
+     * @since 1.1.0
+     */
+    @Nonnull
+    public List<String> getCombinations() {
+        return combinations;
+    }
+
+    private Object readResolve() {
+        if (combinations == null) {
+            // < 1.1.0
+            return new MatrixCombinationsParameterValue(
+                getName(),
+                getValues(),
+                getConfs(),
+                getDescription()
+            );
+        }
+        return this;
+    }
+
+    private static List<String> convertValuesAndConfs(Boolean[] values, String[] confs) {
+        List<String> ret = new ArrayList<String>();
+
+        for (int i = 0; i < values.length; ++i) {
+            if (values[i] != null && values[i]) {
+                ret.add(confs[i]);
+            }
+        }
+        return ret;
     }
 
     @Override
@@ -68,37 +127,25 @@ public class MatrixCombinationsParameterValue extends ParameterValue {
                     return null;
                 }
 
-                List<String> conds = new ArrayList<String>();
-
-                for (int uniqueIdIndex= 0 ; uniqueIdIndex < values.length ; uniqueIdIndex++){
-                    Boolean value=values[uniqueIdIndex];
-                    String conf = confs[uniqueIdIndex];
-
-                    if (value.booleanValue()){
-                        conds.add("("+conf.replace("="," == '").replace(",","' && ")+"')");
-
+                return StringUtils.join(Lists.transform(
+                    getCombinations(),
+                    new Function<String, String>() {
+                        public String apply(String combination) {
+                            return String.format(
+                                "(%s')",
+                                combination.replace("=", " == '").replace(",", "' && ")
+                            );
+                        }
                     }
-
-
-                }
-                return StringUtils.join(conds, " || ");
-
-
+                ), " || ");
             }
         };
     }
+
     public boolean combinationExists(AxisList axes, Combination c){
-
-
-        if (values == null || confs == null || values.length != confs.length)
-            return false;
-
-        for (int i = 0; i < values.length ; i++){
-            if (confs[i].equals(c.toString()) && values[i]==true)
-                return true;
-        }
-        return false;
+        return getCombinations().contains(c.toString());
     }
+
     @Deprecated
     public boolean combinationExists(Combination c){
         return combinationExists(null, c);
@@ -125,32 +172,15 @@ public class MatrixCombinationsParameterValue extends ParameterValue {
         }
         MatrixCombinationsParameterValue other = (MatrixCombinationsParameterValue)obj;
 
-        if (values.length!= other.getValues().length) {
-            return false;
-        }
-        for (int i=0; i< values.length;i++){
-            if (values[i].booleanValue()!=other.getValues()[i].booleanValue())
-                return false;
-        }
-
-        if (confs.length!= other.getConfs().length) {
-            return false;
-        }
-        for (int i=0; i< values.length;i++){
-            if (!confs[i].equals(other.getConfs()[i]))
-                return false;
-        }
-
-        return true;
+        return getCombinations().equals(other.getCombinations());
     }
 
     @Override
     public String toString() {
         StringBuffer valueStr= new StringBuffer("");
         valueStr.append("(MatrixCombinationsParameterValue) " + getName()+"\n");
-        for (int i=0; i< values.length; i++)
-        {
-            valueStr.append(String.format("%s:%s%n",confs[i],values[i]));
+        for (String combination: getCombinations()) {
+            valueStr.append(String.format("%s\n", combination));
         }
         return valueStr.toString();
     }

--- a/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue.java
+++ b/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue.java
@@ -43,8 +43,9 @@ import com.google.common.collect.Lists;
 
 
 public class MatrixCombinationsParameterValue extends ParameterValue {
+    private static final long serialVersionUID = 1L;
 
-    private final List<String> combinations;
+    private List<String> combinations;
 
     @Deprecated
     transient Boolean[] values;
@@ -95,21 +96,22 @@ public class MatrixCombinationsParameterValue extends ParameterValue {
         return combinations;
     }
 
-    private Object readResolve() {
+    protected Object readResolve() {
         if (combinations == null) {
             // < 1.1.0
-            return new MatrixCombinationsParameterValue(
-                getName(),
-                getValues(),
-                getConfs(),
-                getDescription()
-            );
+            this.combinations = convertValuesAndConfs(this.values, this.confs);
+            this.confs = null;
+            this.values = null;
         }
         return this;
     }
 
     private static List<String> convertValuesAndConfs(Boolean[] values, String[] confs) {
         List<String> ret = new ArrayList<String>();
+
+        if (values == null || confs == null) {
+            return ret;
+        }
 
         for (int i = 0; i < values.length; ++i) {
             if (values[i] != null && values[i]) {
@@ -180,7 +182,7 @@ public class MatrixCombinationsParameterValue extends ParameterValue {
         StringBuffer valueStr= new StringBuffer("");
         valueStr.append("(MatrixCombinationsParameterValue) " + getName()+"\n");
         for (String combination: getCombinations()) {
-            valueStr.append(String.format("%s\n", combination));
+            valueStr.append(String.format("%s%n", combination));
         }
         return valueStr.toString();
     }

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
@@ -75,8 +75,7 @@ private void drawMainBall(MatrixCombinationsParameterDefinition paramDef, Combin
             }
             checked = combination.evalGroovyExpression(axes, paramDef.defaultCombinationFilter?:project.combinationFilter)
             span(class: "combination", "data-combination": combination.toIndex(axes)) {
-                f.checkbox(checked: checked, name: "values")
-                input(type: "hidden", name: "confs", value: combination.toString())
+                f.checkbox(checked: checked, name: "combinations", json: combination.toString())
             }
         }
 
@@ -88,8 +87,7 @@ private void drawMainBall(MatrixCombinationsParameterDefinition paramDef, Combin
         
         checked = combination.evalGroovyExpression(axes, paramDef.defaultCombinationFilter?:project.combinationFilter)
         span(class: "combination", "data-combination": combination.toIndex(axes)) {
-            f.checkbox(checked: checked, name: "values")
-            input(type: "hidden", name: "confs", value: combination.toString())
+            f.checkbox(checked: checked, name: "combinations", json: combination.toString())
         }
     }
 

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/rebuild.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/rebuild.groovy
@@ -74,8 +74,7 @@ private void drawTableBall(Combination combination,AxisList axes,matrixValue,Mat
             }
         }
         span(class: "combination", "data-combination": combination.toIndex(axes)) {
-            f.checkbox(checked: true, name: "values");
-            input(type: "hidden", name: "confs", value: combination.toString());
+            f.checkbox(checked: true, name: "combinations", json: combination.toString());
         }
 
     } else {
@@ -84,8 +83,7 @@ private void drawTableBall(Combination combination,AxisList axes,matrixValue,Mat
           text(combination.toString(layouter.z))
         }
         span(class: "combination", "data-combination": combination.toIndex(axes)) {
-            f.checkbox(checked: "false", name: "values")
-            input(type: "hidden", name: "confs", value: combination.toString())
+            f.checkbox(checked: "false", name: "combinations", json: combination.toString())
         }
     }
 }

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/value.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/value.groovy
@@ -61,8 +61,7 @@ private void drawTableBall(Combination combination,AxisList axes,MatrixCombinati
                 text(combination.toString(layouter.z))
               }
             span(class: "combination", "data-combination": combination.toIndex(axes)) {
-                f.checkbox(checked: true, name: "values", readonly: true);
-                input(type: "hidden", name: "confs", value: combination.toString());
+                f.checkbox(checked: true, name: "combinations", readonly: true, json: combination.toString());
             }
         }
 
@@ -72,8 +71,7 @@ private void drawTableBall(Combination combination,AxisList axes,MatrixCombinati
             text(combination.toString(layouter.z))
           }
         span(class: "combination", "data-combination": combination.toIndex(axes)) {
-            f.checkbox(checked: false, name: "values", readonly: true);
-            input(type: "hidden", name: "confs", value: combination.toString());
+            f.checkbox(checked: false, name: "combinations", readonly: true, json: combination.toString());
         }
     }
 }

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValueTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValueTest.java
@@ -24,7 +24,11 @@
 
 package hudson.plugins.matrix_configuration_parameter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.util.Arrays;
+import java.util.Collections;
 
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixBuild;
@@ -35,6 +39,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
+import jenkins.model.Jenkins;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -114,5 +119,59 @@ public class MatrixCombinationsParameterValueTest {
         
         WebClient wc = j.createWebClient();
         wc.getPage(b, "parameters");
+    }
+
+    @Test
+    public void testReadResolve() throws Exception {
+        final String SERIALIZED = 
+            "<hudson.plugins.matrix__configuration__parameter.MatrixCombinationsParameterValue>"
+                + "<name>combinations</name>"
+                + "<description>test</description>"
+                + "<values>"
+                    + "<boolean>true</boolean>"
+                    + "<boolean>false</boolean>"
+                    + "<boolean>true</boolean>"
+                + "</values>"
+                + "<confs>"
+                    + "<string>axis1=value1</string>"
+                    + "<string>axis1=value2</string>"
+                    + "<string>axis1=value3</string>"
+                + "</confs>"
+            + "</hudson.plugins.matrix__configuration__parameter.MatrixCombinationsParameterValue>";
+        MatrixCombinationsParameterValue v = (MatrixCombinationsParameterValue)Jenkins.XSTREAM2.fromXML(SERIALIZED);
+        assertEquals("combinations", v.getName());
+        assertEquals("test", v.getDescription());
+        assertNull(v.getValues());
+        assertNull(v.getConfs());
+        assertEquals(
+            Arrays.asList(
+                "axis1=value1",
+                "axis1=value3"
+            ),
+            v.getCombinations()
+        );
+    }
+
+    @Test
+    public void testReadResolveOfDefaultMatrixCombinationsParameterValue() throws Exception {
+        final String SERIALIZED = 
+            "<hudson.plugins.matrix__configuration__parameter.DefaultMatrixCombinationsParameterValue>"
+                + "<name>combinations</name>"
+                + "<description>test</description>"
+                + "<combinationFilter>axis1 != &apos;value2&apos;</combinationFilter>"
+            + "</hudson.plugins.matrix__configuration__parameter.DefaultMatrixCombinationsParameterValue>";
+        DefaultMatrixCombinationsParameterValue v = (DefaultMatrixCombinationsParameterValue)Jenkins.XSTREAM2.fromXML(SERIALIZED);
+        assertEquals("combinations", v.getName());
+        assertEquals("test", v.getDescription());
+        assertNull(v.getValues());
+        assertNull(v.getConfs());
+        assertEquals(
+            Collections.emptyList(),
+            v.getCombinations()
+        );
+        assertEquals(
+            "axis1 != 'value2'",
+            v.getCombinationFilter()
+        );
     }
 }


### PR DESCRIPTION
Now the values from the build parameters page are passed as a pair of all combination names and check statuses.
This change simplifies passing values only with checked combination names.