### PR TITLE
Make tests run with jdk8 avoiding JENKINS-18537.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,13 @@
         <version>1.21</version> <!-- RebuildParameterProvider is available since 1.21 -->
         <optional>true</optional>
       </dependency>
+      <!-- JENKINS-18537 (fixed in Jenkins 1.557 or 1554.1 -->
+      <dependency>
+        <groupId>org.jvnet.hudson</groupId>
+        <artifactId>xstream</artifactId>
+        <version>1.4.7-jenkins-1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 
   <build>


### PR DESCRIPTION
Tests on Jenkins fails for [JENKINS-18537](https://issues.jenkins-ci.org/browse/JENKINS-18537).

This change avoids the problem.