### PR TITLE
[JENKINS-37815] Support buildWithParameters

### DIFF
--- a/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition.java
+++ b/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition.java
@@ -24,16 +24,13 @@
 package hudson.plugins.matrix_configuration_parameter;
 
 import hudson.Extension;
-import hudson.cli.CLICommand;
-import hudson.model.ParameterDefinition;
-import hudson.model.ParameterValue;
 import hudson.model.Result;
+import hudson.model.SimpleParameterDefinition;
 import hudson.plugins.matrix_configuration_parameter.shortcut.MatrixCombinationsShortcut;
 import hudson.plugins.matrix_configuration_parameter.shortcut.MatrixCombinationsShortcutDescriptor;
 import hudson.plugins.matrix_configuration_parameter.shortcut.ResultShortcut;
 import net.sf.json.JSONObject;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -46,7 +43,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 
-public class MatrixCombinationsParameterDefinition extends ParameterDefinition {
+public class MatrixCombinationsParameterDefinition extends SimpleParameterDefinition {
 
     private static final long serialVersionUID = 1L;
     private final String defaultCombinationFilter;
@@ -115,39 +112,17 @@ public class MatrixCombinationsParameterDefinition extends ParameterDefinition {
     }
 
     @Override
-    public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
+    public MatrixCombinationsParameterValue createValue(StaplerRequest req, JSONObject jo) {
         MatrixCombinationsParameterValue value = req.bindJSON(MatrixCombinationsParameterValue.class, jo);
         value.setDescription(getDescription());
         return value;
-    }
-
-    @Override
-    public ParameterValue createValue(StaplerRequest req) {
-        String[] value = req.getParameterValues(getName());
-        if (value == null || value.length < 1) {
-            return getDefaultParameterValue();
-        } else {
-            return new MatrixCombinationsParameterValue(getName(),new Boolean[]{},new String[]{});
-        }
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ParameterValue createValue(CLICommand command, String value) throws IOException, InterruptedException {
-        return createValue(value);
-    }
-
-    /**
-     * Decide combinations from combinations filter
-     *
-     * @param value groovy expression for combinations filter
-     * @return matrix-combinations parameter with the specified combinations filter
-     *
-     * @since 1.1.0
-     */
-    protected ParameterValue createValue(String value) throws IOException, InterruptedException {
+    public MatrixCombinationsParameterValue createValue(String value) {
         return new DefaultMatrixCombinationsParameterValue(
             getName(),
             getDescription(),
@@ -157,8 +132,7 @@ public class MatrixCombinationsParameterDefinition extends ParameterDefinition {
 
     @Override
     public MatrixCombinationsParameterValue getDefaultParameterValue() {
-        MatrixCombinationsParameterValue v = new DefaultMatrixCombinationsParameterValue(getName(), getDescription(), getDefaultCombinationFilter());
-        return v;
+        return createValue(getDefaultCombinationFilter());
     }
 
     @Extension

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinitionTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinitionTest.java
@@ -26,6 +26,8 @@ package hudson.plugins.matrix_configuration_parameter;
 
 import static org.junit.Assert.*;
 
+import java.net.URLEncoder;
+
 import hudson.cli.CLI;
 import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
@@ -579,6 +581,31 @@ public class MatrixCombinationsParameterDefinitionTest {
             "combinations=axis1 in ['value1', 'value3']"
         );
         assertEquals(0, ret);
+
+        j.waitUntilNoActivity();
+
+        MatrixBuild b = p.getLastBuild();
+        j.assertBuildStatusSuccess(b);
+
+        assertNotNull(b.getExactRun(new Combination(axes, "value1")));
+        assertNull(b.getExactRun(new Combination(axes, "value2")));
+        assertNotNull(b.getExactRun(new Combination(axes, "value3")));
+    }
+
+    @Test
+    public void testBuildWithParameters() throws Exception {
+        AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
+        MatrixProject p = j.createMatrixProject();
+        p.setAxes(axes);
+        p.addProperty(new ParametersDefinitionProperty(
+            new MatrixCombinationsParameterDefinition("combinations", "", "")
+        ));
+
+        WebClient wc = j.createWebClient();
+        wc.getPage(p, String.format(
+            "/buildWithParameters?combinations=%s",
+            URLEncoder.encode("axis1 in ['value1', 'value3']", "UTF-8")
+        ));
 
         j.waitUntilNoActivity();
 


### PR DESCRIPTION
[JENKINS-37815](https://issues.jenkins-ci.org/browse/JENKINS-37815)

You can trigger builds with parameters by accessing
http://(jenkins url)/jobs/(job name)/buildWithParameters?param1=value1

Matrix-combinations-parameter plugin doesn't support `buildWithParameters` and results no combinations are selected.
With this change, passing a combination filter expression to `buildWithParameters` make matrix-combinations-parameter work.