### PR TITLE
[FIXED JENKINS-42626] Avoid NPE when adding "By build result"

### DIFF
--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/shortcut/ResultShortcut/config.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/shortcut/ResultShortcut/config.groovy
@@ -36,7 +36,7 @@ f.entry(field: "resultsToCheck", title: _("Results to check")) {
     for (Result r: [Result.SUCCESS, Result.UNSTABLE, Result.FAILURE, Result.NOT_BUILT, Result.ABORTED]) {
         f.checkbox(
             json: r.toString(),
-            checked: instance.resultsToCheck.contains(r.toString()),
+            checked: instance?instance.resultsToCheck.contains(r.toString()):false,
             title: r.toString()
         );
     }


### PR DESCRIPTION
[JENKINS-42626](https://issues.jenkins-ci.org/browse/JENKINS-42626)

NPE happens when adding "By build result".
It is caused as `instance` is `null` for the new component.
Fixed by adding null check.

Unfortunately there's no unittest as adding an component in configuration pages is difficult to test in unittests.
I tested the fix by running the plugin locally.
