### PR TITLE
[FIXED JENKINS-39157] Remove the duplicated parameter name display

### DIFF
--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
@@ -46,10 +46,6 @@ Layouter layouter = new Layouter<Combination>(axes) {
 drawMainBody(paramDef, f, nameIt, axes, project, project.lastBuild, layouter)
 
 private void drawMainBody(MatrixCombinationsParameterDefinition paramDef, Namespace f, String nameIt, AxisList axes,MatrixProject project,MatrixBuild build,Layouter layouter) {
-
-    drawMainLinksJS(nameIt)
-
-
     f.entry(title: nameIt, description: it.getDescription()) {
         div(name: "parameter", class: "matrix-combinations-parameter") {
             input(type: "hidden", name: "name", value: nameIt)


### PR DESCRIPTION
[JENKINS-39157](https://issues.jenkins-ci.org/browse/JENKINS-39157)

This is caused for a mistake in #15.
`drawMainLinksJS()` is removed in that request, but the code calling `drawMainLinksJS()` is left.
Calling unknown function in groovy files in Jenkins are translated as tag definitions and output as `<drawMainLinksJS>paramname</drawMainLinksJS>`.
This results duplicated name displaying.