### PR TITLE
[JENKINS-42902] Sanitize names and descriptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
   </scm>
 
     <properties>
-        <jenkins.version>1.509</jenkins.version>
-        <jenkins-test-harness.version>1.509</jenkins-test-harness.version>
-        <java.level>5</java.level>
+        <jenkins.version>1.532</jenkins.version> <!-- ParameterDefinition#getFormattedDescription is since 1.520 -->
+        <jenkins-test-harness.version>1.532</jenkins-test-harness.version>
+        <java.level>6</java.level>
     </properties>
 
 	<repositories>
@@ -65,35 +65,6 @@
           <!-- jenkins-test-harness < 1.545 doesn't support concurrent tests. -->
           <forkCount>1</forkCount>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>display-info</id>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <excludes>
-                    <!-- <exclude>org.sonatype.sisu:sisu-guice</exclude> -->
-                    <exclude>log4j:log4j:*:jar:compile</exclude>
-                    <exclude>log4j:log4j:*:jar:runtime</exclude>
-                    <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
-                    <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
-                  </excludes>
-                </bannedDependencies>
-                <enforceBytecodeVersion>
-                  <excludes combine.children="append">
-                    <exclude>com.sonyericsson.hudson.plugins.rebuild:rebuild</exclude>
-                    <!-- dependencies via jenkins-core-1.509 -->
-                    <exclude>org.mindrot:jbcrypt</exclude>
-                    <exclude>org.kohsuke:asm3</exclude>
-                  </excludes>
-                </enforceBytecodeVersion>
-              </rules>
-          </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue.java
+++ b/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue.java
@@ -23,17 +23,22 @@
  */
 package hudson.plugins.matrix_configuration_parameter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
+import hudson.markup.MarkupFormatter;
 import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
 import hudson.model.*;
 
 import hudson.util.VariableResolver;
+import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -44,6 +49,8 @@ import com.google.common.collect.Lists;
 
 public class MatrixCombinationsParameterValue extends ParameterValue {
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(MatrixCombinationsParameterValue.class.getName());
 
     private List<String> combinations;
 
@@ -186,4 +193,25 @@ public class MatrixCombinationsParameterValue extends ParameterValue {
         }
         return valueStr.toString();
     }
+
+    /**
+     * return parameter description, applying the configured {@link MarkupFormatter} for jenkins instance.
+     *
+     * This is a backport from Jenkins-2.44 or Jenkins-2.32.2.
+     *
+     * @since 1.2.0
+     */
+    public String getFormattedDescription() {
+        try {
+            return Jenkins.getInstance().getMarkupFormatter().translate(getDescription());
+        } catch (IOException e) {
+            LOGGER.log(
+                Level.WARNING,
+                "failed to translate description using configured markup formatter: {0}",
+                getDescription()
+            );
+            return "";
+        }
+    }
+
 }

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/config.jelly
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/config.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
         <f:textbox field="name" />
     </f:entry>
     <f:entry title="${%Description}" help="/help/parameter/description.html">
-        <f:textarea field="description" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
+        <f:textarea field="description" previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
     <f:advanced>
         <f:entry field="defaultCombinationFilter" title="${%Default Filter}">

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/config.jelly
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/config.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
         <f:textbox field="name" />
     </f:entry>
     <f:entry title="${%Description}" help="/help/parameter/description.html">
-        <f:textarea field="description" />
+        <f:textarea field="description" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
     <f:advanced>
         <f:entry field="defaultCombinationFilter" title="${%Default Filter}">

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinition/index.groovy
@@ -23,7 +23,8 @@ String nameIt = it.getName();
 MatrixProject project = request.findAncestorObject(MatrixProject.class);
 if (project == null) {
    //in case project is not a Matrix Project
-    f.entry(title: nameIt, description: it.getDescription()) {
+    set("escapeEntryTitleAndDescription", false);
+    f.entry(title: h.escape(nameIt), description: it.formattedDescription) {
         div(name: "parameter") {
             input(type: "hidden", name: "name", value: nameIt)
             text(_("Not applicable. Applicable only to multi-configuration projects."))
@@ -46,7 +47,8 @@ Layouter layouter = new Layouter<Combination>(axes) {
 drawMainBody(paramDef, f, nameIt, axes, project, project.lastBuild, layouter)
 
 private void drawMainBody(MatrixCombinationsParameterDefinition paramDef, Namespace f, String nameIt, AxisList axes,MatrixProject project,MatrixBuild build,Layouter layouter) {
-    f.entry(title: nameIt, description: it.getDescription()) {
+    set("escapeEntryTitleAndDescription", false);
+    f.entry(title: h.escape(nameIt), description: it.formattedDescription) {
         div(name: "parameter", class: "matrix-combinations-parameter") {
             input(type: "hidden", name: "name", value: nameIt)
             nsProject.matrix(it: project, layouter: layouter) {

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/rebuild.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/rebuild.groovy
@@ -24,7 +24,8 @@ MatrixProject project = request.findAncestorObject(MatrixProject.class);
 MatrixBuild build = request.findAncestorObject(MatrixBuild.class);
 if (project == null || build == null) {
     //in case you are looking at a specific run, MatrixRun Ancestor will replace the MatrixBuild
-    f.entry(title: valueIt.getName(), description: it.getDescription()) {
+    set("escapeEntryTitleAndDescription", false);
+    f.entry(title: h.escape(valueIt.name), description: it.formattedDescription) {
         // In the case the parameter is not defined in this project,
         // sending parameters cause rebuild-plugin throws exception.
         // Acts as if I'm not here.
@@ -49,7 +50,8 @@ drawParameterBody(parameterDefinition, f, valueIt, axes, project, build, layoute
 
 
 private void drawParameterBody(MatrixCombinationsParameterDefinition paramDef, Namespace f,valueIt,AxisList axes,MatrixProject project,MatrixBuild build,Layouter layouter) {
-    f.entry(title: valueIt.getName(), description: it.getDescription()) {
+    set("escapeEntryTitleAndDescription", false);
+    f.entry(title: h.escape(valueIt.name), description: it.formattedDescription) {
         div(name: "parameter", class: "matrix-combinations-parameter") {
             input(type: "hidden", name: "name", value: valueIt.getName())
             nsProject.matrix(it: build, layouter: layouter) {

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/value.groovy
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue/value.groovy
@@ -20,7 +20,8 @@ MatrixProject project = request.findAncestorObject(MatrixProject.class);
 MatrixBuild build = request.findAncestorObject(MatrixBuild.class);
 if (project == null || build == null) {
     //in case you are looking at a specific run, MatrixRun Ancestor will replace the MatrixBuild
-    f.entry(title: valueIt.getName(), description: it.getDescription()) {
+    set("escapeEntryTitleAndDescription", false);
+    f.entry(title: h.escape(valueIt.name), description: it.formattedDescription) {
         div(name: "parameter") {
             input(type: "hidden", name: "name", value: valueIt.getName())
             text(_("Not applicable. Applicable only to multi-configuration projects."))
@@ -40,7 +41,8 @@ drawParameterBody(f, valueIt, axes, project, build, layouter);
 
 
 private void drawParameterBody(Namespace f,MatrixCombinationsParameterValue valueIt,AxisList axes,MatrixProject project,MatrixBuild build,Layouter layouter) {
-    f.entry(title: valueIt.getName(), description: it.getDescription()) {
+    set("escapeEntryTitleAndDescription", false);
+    f.entry(title: h.escape(valueIt.name), description: it.formattedDescription) {
         div(name: "parameter", class: "matrix-combinations-parameter") {
             input(type: "hidden", name: "name", value: valueIt.getName())
             nsProject.matrix(it: build, layouter: layouter) {

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsRebuildParameterProviderTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsRebuildParameterProviderTest.java
@@ -41,9 +41,11 @@ import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.StringParameterValue;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -216,5 +218,51 @@ public class MatrixCombinationsRebuildParameterProviderTest
         j.assertCombinationChecked(page, false, axes, "value1");
         j.assertCombinationChecked(page, true, axes, "value2");
         j.assertCombinationChecked(page, false, axes, "value3");
+    }
+
+    @Issue("JENKINS-42902")
+    @Test
+    public void testSafeTitle() throws Exception {
+        AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
+        MatrixProject p = j.createMatrixProject();
+        p.setAxes(axes);
+        p.addProperty(new ParametersDefinitionProperty(
+                new MatrixCombinationsParameterDefinition(
+                    "<span id=\"test-not-expected\">combinations</span>",
+                    ""
+                )
+        ));
+
+        MatrixBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+
+        WebClient wc = j.createWebClient();
+        HtmlPage page = wc.getPage(b, "rebuild");
+
+        assertNull(page.getElementById("test-not-expected"));
+    }
+
+    @Issue("JENKINS-42902")
+    @Test
+    public void testSafeDescription() throws Exception {
+        Assume.assumeNotNull(j.jenkins.getMarkupFormatter());
+
+        AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
+        MatrixProject p = j.createMatrixProject();
+        p.setAxes(axes);
+        p.addProperty(new ParametersDefinitionProperty(
+                new MatrixCombinationsParameterDefinition(
+                    "combinations",
+                    "<span id=\"test-expected\">blahblah</span>"
+                        + "<script id=\"test-not-expected\"></script>"
+                )
+        ));
+
+        MatrixBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+
+        WebClient wc = j.createWebClient();
+        HtmlPage page = wc.getPage(b, "rebuild");
+
+        assertNotNull(page.getElementById("test-expected"));
+        assertNull(page.getElementById("test-not-expected"));
     }
 }


### PR DESCRIPTION
[JENKINS-42902](https://issues.jenkins-ci.org/browse/JENKINS-42902)

HTML texts in descriptions of matrix-combinations-parameters get escaped since Jenkins-2.32.2.
This is caused for the fix for SECURITY-353.

Related commits:
* jenkinsci/jenkins@b561ca5696f12d8e017f79cc2080c394c6710719
* jenkinsci/jenkins@0b471b7b693eb370c52c82382257419a07171f93

This means matrix-combinations-parameter plugin cause XSS when used with Jenkins < 2.32.2.
This requests applies appropriate HTML escaping.