### PR TITLE
[JENKINS-49573] - Update the plugin make it compatible with Jenkins 2.102+ and to support PCT runs 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin(jenkinsVersions: [null, '2.104'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,3 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(jenkinsVersions: [null, '2.104'])
+// TODO: test version beyond 2.102 (JEP-200)
+buildPlugin(jenkinsVersions: [null])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.9</version>
+        <version>3.4</version>
     </parent>
     <artifactId>matrix-combinations-parameter</artifactId>
     <packaging>hpi</packaging>
@@ -21,51 +21,42 @@
   </scm>
 
     <properties>
-        <jenkins.version>1.532</jenkins.version> <!-- ParameterDefinition#getFormattedDescription is since 1.520 -->
-        <jenkins-test-harness.version>1.532</jenkins-test-harness.version>
-        <java.level>6</java.level>
+        <jenkins.version>1.625.3</jenkins.version>
+        <java.level>7</java.level>
     </properties>
 
 	<repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-	
 
     <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>matrix-project</artifactId>
+        <version>1.12</version>
+      </dependency>
       <dependency>
         <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
         <artifactId>rebuild</artifactId>
         <version>1.21</version> <!-- RebuildParameterProvider is available since 1.21 -->
         <optional>true</optional>
       </dependency>
-      <!-- JENKINS-18537 (fixed in Jenkins 1.557 or 1554.1 -->
       <dependency>
-        <groupId>org.jvnet.hudson</groupId>
-        <artifactId>xstream</artifactId>
-        <version>1.4.7-jenkins-1</version>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>antisamy-markup-formatter</artifactId>
+        <version>1.5</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- jenkins-test-harness < 1.545 doesn't support concurrent tests. -->
-          <forkCount>1</forkCount>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue.java
+++ b/src/main/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValue.java
@@ -203,7 +203,7 @@ public class MatrixCombinationsParameterValue extends ParameterValue {
      */
     public String getFormattedDescription() {
         try {
-            return Jenkins.getInstance().getMarkupFormatter().translate(getDescription());
+            return Jenkins.getActiveInstance().getMarkupFormatter().translate(getDescription());
         } catch (IOException e) {
             LOGGER.log(
                 Level.WARNING,

--- a/src/main/java/hudson/plugins/matrix_configuration_parameter/shortcut/MatrixCombinationsShortcutDescriptor.java
+++ b/src/main/java/hudson/plugins/matrix_configuration_parameter/shortcut/MatrixCombinationsShortcutDescriptor.java
@@ -38,6 +38,6 @@ public abstract class MatrixCombinationsShortcutDescriptor
         extends Descriptor<MatrixCombinationsShortcut>
 {
     public static List<MatrixCombinationsShortcutDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(MatrixCombinationsShortcut.class);
+        return Jenkins.getActiveInstance().getDescriptorList(MatrixCombinationsShortcut.class);
     }
 }

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,1 @@
+com.google.common.collect.Lists$TransformingRandomAccessList

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsJenkinsRule.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsJenkinsRule.java
@@ -24,8 +24,14 @@
 
 package hudson.plugins.matrix_configuration_parameter;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.DomNode;
+import hudson.matrix.MatrixProject;
 import org.apache.commons.httpclient.HttpStatus;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -37,6 +43,10 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.IOException;
 
 /**
  *
@@ -80,11 +90,11 @@ public class MatrixCombinationsJenkinsRule extends JenkinsRule {
     }
 
     public void checkCombination(HtmlPage page, int index, boolean checked, AxisList axes, String... values) throws Exception {
-        page.<HtmlElement>selectNodes("//*[@class='matrix-combinations-parameter']").get(index)
-            .<HtmlCheckBoxInput>selectNodes(String.format(
-                "//*[@data-combination='%s']//input[@type='checkbox']",
-                new Combination(axes, values).toIndex(axes)
-            )).get(0).setChecked(checked);
+        HtmlElement param = byXPath(page.getDocumentElement(), "//*[@class='matrix-combinations-parameter']", index, HtmlElement.class);
+        HtmlCheckBoxInput checkbox = firstByXPath(param, String.format(
+                ".//*[@data-combination='%s']//input[@type='checkbox']",
+                new Combination(axes, values).toIndex(axes)), HtmlCheckBoxInput.class);
+        checkbox.setChecked(checked);
     }
 
     public void clickShortcut(HtmlPage page, String name) throws Exception {
@@ -92,11 +102,9 @@ public class MatrixCombinationsJenkinsRule extends JenkinsRule {
     }
 
     public void clickShortcut(HtmlPage page, int index, String name) throws Exception {
-        page.<HtmlElement>selectNodes("//*[@class='matrix-combinations-parameter']").get(index)
-            .<HtmlAnchor>selectNodes(String.format(
-                ".//a[@data-shortcut-id='%s']",
-                name
-            )).get(0).click();
+        HtmlElement param = byXPath(page.getDocumentElement(), "//*[@class='matrix-combinations-parameter']", index, HtmlElement.class);
+        HtmlElement shortcut = firstByXPath(param, String.format(".//a[@data-shortcut-id='%s']", name));
+        shortcut.click();
     }
 
     public void assertCombinationChecked(HtmlPage page, boolean checked, AxisList axes, String... values) throws Exception {
@@ -104,13 +112,44 @@ public class MatrixCombinationsJenkinsRule extends JenkinsRule {
     }
 
     public void assertCombinationChecked(HtmlPage page, int index, boolean checked, AxisList axes, String... values) throws Exception {
-        assertEquals(
-            checked,
-            page.<HtmlElement>selectNodes("//*[@class='matrix-combinations-parameter']").get(index)
-                .<HtmlCheckBoxInput>selectNodes(String.format(
-                    ".//*[@data-combination='%s']//input[@type='checkbox']",
-                    new Combination(axes, values).toIndex(axes)
-                )).get(0).isChecked()
-        );
+        HtmlElement param = byXPath(page.getDocumentElement(), "//*[@class='matrix-combinations-parameter']", index, HtmlElement.class);
+        HtmlCheckBoxInput checkbox = firstByXPath(param, String.format(
+                        ".//*[@data-combination='%s']//input[@type='checkbox']",
+                        new Combination(axes, values).toIndex(axes)), HtmlCheckBoxInput.class);
+        assertEquals(checked, checkbox.isChecked());
+    }
+
+    @Nonnull
+    protected static HtmlElement nodeToElement(@CheckForNull DomNode node) {
+        return nodeToElement(node, HtmlElement.class);
+    }
+
+    @Nonnull
+    protected static <T extends Object> T nodeToElement(@CheckForNull Object node, Class<T> c) throws AssertionError {
+        assertNotNull("Node is null", node);
+        assertThat(String.format("Node is not %s: %s", c, node), node, instanceOf(c));
+        return (T)node;
+    }
+
+    @Nonnull
+    protected static HtmlElement firstByXPath(@Nonnull HtmlElement root, String xpath) throws AssertionError {
+        return byXPath(root, xpath, 0, HtmlElement.class);
+    }
+
+    @Nonnull
+    protected static <T extends Object> T firstByXPath(@Nonnull HtmlElement root, String xpath, Class<T> c) throws AssertionError {
+        return byXPath(root, xpath, 0, c);
+    }
+
+    @Nonnull
+    protected static <T extends Object> T byXPath(@Nonnull HtmlElement root, String xpath, int index, Class<T> c) throws AssertionError {
+        Object o = root.getByXPath(xpath).get(index);
+        assertNotNull(String.format("Failed to fetch element #%d for query '%s'. Node: %s", index, xpath, root), o);
+        assertThat(String.format("Node is not %s: %s", c, o), o, instanceOf(c));
+        return (T)o;
+    }
+
+    public MatrixProject createMatrixProject() throws IOException {
+        return createProject(MatrixProject.class);
     }
 }

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinitionTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinitionTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.*;
 import java.net.URLEncoder;
 
 import hudson.cli.CLI;
+import hudson.markup.RawHtmlMarkupFormatter;
 import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
 import hudson.matrix.MatrixBuild;
@@ -621,6 +622,7 @@ public class MatrixCombinationsParameterDefinitionTest {
     @Issue("JENKINS-42902")
     @Test
     public void testSafeTitle() throws Exception {
+        j.jenkins.setMarkupFormatter(new RawHtmlMarkupFormatter(true));
         AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
         MatrixProject p = j.createMatrixProject();
         p.setAxes(axes);
@@ -640,7 +642,7 @@ public class MatrixCombinationsParameterDefinitionTest {
     @Issue("JENKINS-42902")
     @Test
     public void testSafeDescription() throws Exception {
-        Assume.assumeNotNull(j.jenkins.getMarkupFormatter());
+        j.jenkins.setMarkupFormatter(new RawHtmlMarkupFormatter(true));
 
         AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
         MatrixProject p = j.createMatrixProject();

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinitionTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterDefinitionTest.java
@@ -26,8 +26,11 @@ package hudson.plugins.matrix_configuration_parameter;
 
 import static org.junit.Assert.*;
 
+import java.net.URL;
 import java.net.URLEncoder;
 
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.WebRequest;
 import hudson.cli.CLI;
 import hudson.markup.RawHtmlMarkupFormatter;
 import hudson.matrix.AxisList;
@@ -575,12 +578,8 @@ public class MatrixCombinationsParameterDefinitionTest {
 
         CLI cli = new CLI(j.getURL());
         int ret = cli.execute(
-            "build",
-            p.getFullName(),
-            "-p",
-            // You can't use axis1 != 'value2'
-            // for JENKINS-21160 (fixed in Jenkins 1.606)
-            "combinations=axis1 in ['value1', 'value3']"
+            "build", p.getFullName(),
+            "-p", "combinations=axis1 != 'value2'"
         );
         assertEquals(0, ret);
 
@@ -604,10 +603,10 @@ public class MatrixCombinationsParameterDefinitionTest {
         ));
 
         WebClient wc = j.createWebClient();
-        wc.getPage(p, String.format(
-            "/buildWithParameters?combinations=%s",
-            URLEncoder.encode("axis1 in ['value1', 'value3']", "UTF-8")
-        ));
+        URL url = new URL(wc.createCrumbedUrl(p.getUrl() + "buildWithParameters").toString()
+                + "&combinations=" + URLEncoder.encode("axis1 != 'value2'", "UTF-8"));
+        WebRequest request = new WebRequest(url, HttpMethod.POST);
+        wc.getPage(request);
 
         j.waitUntilNoActivity();
 

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValueTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsParameterValueTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertNull;
 import java.util.Arrays;
 import java.util.Collections;
 
+import hudson.markup.RawHtmlMarkupFormatter;
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
@@ -181,6 +182,7 @@ public class MatrixCombinationsParameterValueTest {
     @Issue("JENKINS-42902")
     @Test
     public void testSafeTitle() throws Exception {
+        j.jenkins.setMarkupFormatter(new RawHtmlMarkupFormatter(true));
         AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
         MatrixProject p = j.createMatrixProject();
         p.setAxes(axes);
@@ -202,7 +204,7 @@ public class MatrixCombinationsParameterValueTest {
     @Issue("JENKINS-42902")
     @Test
     public void testSafeDescription() throws Exception {
-        Assume.assumeNotNull(j.jenkins.getMarkupFormatter());
+        j.jenkins.setMarkupFormatter(new RawHtmlMarkupFormatter(true));
 
         AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
         MatrixProject p = j.createMatrixProject();

--- a/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsRebuildParameterProviderTest.java
+++ b/src/test/java/hudson/plugins/matrix_configuration_parameter/MatrixCombinationsRebuildParameterProviderTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.*;
 
 import java.util.Arrays;
 
+import hudson.markup.RawHtmlMarkupFormatter;
 import hudson.matrix.AxisList;
 import hudson.matrix.Combination;
 import hudson.matrix.MatrixBuild;
@@ -223,6 +224,7 @@ public class MatrixCombinationsRebuildParameterProviderTest
     @Issue("JENKINS-42902")
     @Test
     public void testSafeTitle() throws Exception {
+        j.jenkins.setMarkupFormatter(new RawHtmlMarkupFormatter(true));
         AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
         MatrixProject p = j.createMatrixProject();
         p.setAxes(axes);
@@ -244,7 +246,7 @@ public class MatrixCombinationsRebuildParameterProviderTest
     @Issue("JENKINS-42902")
     @Test
     public void testSafeDescription() throws Exception {
-        Assume.assumeNotNull(j.jenkins.getMarkupFormatter());
+        j.jenkins.setMarkupFormatter(new RawHtmlMarkupFormatter(true));
 
         AxisList axes = new AxisList(new TextAxis("axis1", "value1", "value2", "value3"));
         MatrixProject p = j.createMatrixProject();


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-49573

the code fails due to Guava in the following method:

```java
public ResultShortcut(String name, boolean exact, Result... results) {
        this(name, exact, Lists.transform(
            Arrays.asList(results),
            new Function<Result, String>() {
                public String apply(Result result) {
                    return result.toString();
                }
        }));
    }
```

Although it is possible to rework the code, I think it is better to whitelist collection in the plugin and in the Core. I will create a PR to the core tomorrow.

@reviewbybees @jglick 