### PR TITLE
[INFRA-2464] Add configuration for Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+_extends: .github
+tag-template: matrix-combinations-parameter-$NEXT_MINOR_VERSION


### PR DESCRIPTION
I'll make a new release to update the documentation of the plugin site (#26 ).
I also want to switch changelogs to github release notes using Release Drafter: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc .

I'm asking enabling it in https://issues.jenkins-ci.org/browse/INFRA-2464 .
