### PR TITLE
Prepare releasing 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.3.2 (29 Oct 2022)
+
+-   FIXED: grey ball images are broken since Jenkins-2.333 ([JENKINS-69777](https://issues.jenkins.io/browse/JENKINS-69777))
+
 ## Version 1.3.1 (15 Feb 2020)
 
 -   Move wiki-documentation to Github ([Pull request #26](https://github.com/jenkinsci/matrix-combinations-plugin/pull/26))


### PR DESCRIPTION
Planned releasing on 2022-10-29

1.3.2 contains following changes:

* FIXED: grey ball images are broken since Jenkins-2.333
    * [JENKINS-69777](https://issues.jenkins.io/browse/JENKINS-69777) Broken grey ball images after upgrade to Jenkins 2.361
    * #29  [JENKINS-69777] Prepare for icon removal from core

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
