### PR TITLE
[JENKINS-74161] Extract inline JavaScript from `taglib/matrix.jelly`

### DIFF
--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/taglib/matrix.jelly
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/taglib/matrix.jelly
@@ -94,10 +94,7 @@ THE SOFTWARE.
         </table>
       </j:otherwise>
     </j:choose>
-    <j:if test="${ajax==null and attrs.autoRefresh and !h.isAutoRefresh(request)}">
-      <script defer="defer">
-        refreshPart('matrix',"./ajaxMatrix");
-      </script>
-    </j:if>
+    <span class="matrix-auto-refresh-data" data-should-auto-refresh="${ajax==null and attrs.autoRefresh and !h.isAutoRefresh(request)}"/>
+    <st:adjunct includes="hudson.plugins.matrix_configuration_parameter.taglib.matrix.matrix"/>
   </div>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/matrix_configuration_parameter/taglib/matrix/matrix.js
+++ b/src/main/resources/hudson/plugins/matrix_configuration_parameter/taglib/matrix/matrix.js
@@ -1,0 +1,6 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const shouldAutoRefresh = document.querySelector(".matrix-auto-refresh-data").dataset.shouldAutoRefresh === "true";
+    if (shouldAutoRefresh) {
+        refreshPart('matrix',"./ajaxMatrix");
+    }
+});


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74161

`matrix` tag defined in the plugin dose not seem to be used. If it was used it could be fixed like in this PR. If it's indeed unused it's probably better to just remove it completely.
Ecosystem search: https://github.com/search?q=org%3Ajenkinsci%20%22%3Amatrix%20%22&type=code

### Testing done

None, tag is unused (probably).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
